### PR TITLE
#207 Add example for starting up an ASP.NET Web app

### DIFF
--- a/LightInject.Microsoft.DependencyInjection.sln
+++ b/LightInject.Microsoft.DependencyInjection.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{15856E1C-AB65-4DAA-8C57-3478DE8C8420}"
 EndProject
@@ -11,13 +11,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightInject.Microsoft.Depen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightInject.Microsoft.DependencyInjection.Benchmarks", "src\LightInject.Microsoft.DependencyInjection.Benchmarks\LightInject.Microsoft.DependencyInjection.Benchmarks.csproj", "{28EE4FC0-43BB-458A-B186-256207B660B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplicationTest", "WebApplicationTest\WebApplicationTest.csproj", "{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F66CEE6C-90B1-4BF8-80E0-5B2594819F59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -32,10 +31,18 @@ Global
 		{28EE4FC0-43BB-458A-B186-256207B660B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28EE4FC0-43BB-458A-B186-256207B660B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28EE4FC0-43BB-458A-B186-256207B660B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F66CEE6C-90B1-4BF8-80E0-5B2594819F59} = {15856E1C-AB65-4DAA-8C57-3478DE8C8420}
 		{8B4FA81E-8014-44D5-8FF1-09287630355C} = {15856E1C-AB65-4DAA-8C57-3478DE8C8420}
 		{28EE4FC0-43BB-458A-B186-256207B660B5} = {15856E1C-AB65-4DAA-8C57-3478DE8C8420}
+		{01E1A51D-5FC6-4912-AC95-7FD90DCD0B47} = {15856E1C-AB65-4DAA-8C57-3478DE8C8420}
 	EndGlobalSection
 EndGlobal

--- a/WebApplicationTest/Controllers/WeatherForecastController.cs
+++ b/WebApplicationTest/Controllers/WeatherForecastController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebApplicationTest.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/WebApplicationTest/LightInjectHosting.cs
+++ b/WebApplicationTest/LightInjectHosting.cs
@@ -1,0 +1,49 @@
+﻿//Copied from the LightInject hosting repository
+namespace Microsoft.Extensions.Hosting
+{
+    using LightInject;
+    using LightInject.Microsoft.DependencyInjection;
+    using System;
+
+    /// <summary>
+    /// Extends the <see cref="IHostBuilder"/> to enable LightInject to be used as the service container.
+    /// </summary>
+    public static class HostBuilderExtensions
+    {
+        /// <summary>
+        /// Configures the <paramref name="builder"/> to use LightInject as the service container.
+        /// </summary>
+        /// <param name="builder">The target <see cref="IHostBuilder"/>.</param>
+        /// <param name="configureServices">A delegate passing the <see cref="IServiceRegistry"/> used to configure services.</param>
+        /// <param name="configureOptions">A delegate passing the </param>
+        /// <returns>The <see cref="IHostBuilder"/> configured to use LightInject.</returns>
+        public static IHostBuilder UseLightInject(this IHostBuilder builder, Action<IServiceRegistry>? configureServices = null, Action<ContainerOptions> configureOptions = null)
+        {
+            var options = ContainerOptions.Default.Clone().WithMicrosoftSettings().WithAspNetCoreSettings();
+            configureOptions?.Invoke(options);
+            var container = new ServiceContainer(options);
+            container.ConstructorDependencySelector = new AnnotatedConstructorDependencySelector();
+            container.ConstructorSelector = new AnnotatedConstructorSelector(container.CanGetInstance);
+            configureServices?.Invoke(container);
+            return builder.UseServiceProviderFactory(new LightInjectServiceProviderFactory(container));
+        }
+
+    }
+
+    /// <summary>
+    /// Extends the <see cref="ContainerOptions"/> class.
+    /// </summary>
+    public static class ContainerOptionsExtensions
+    {
+        /// <summary>
+        /// Sets up the <see cref="ContainerOptions"/> to be compliant with the conventions used in Microsoft.Extensions.DependencyInjection.
+        /// </summary>
+        /// <param name="options">The target <see cref="ContainerOptions"/>.</param>
+        /// <returns><see cref="ContainerOptions"/>.</returns>
+        public static ContainerOptions WithAspNetCoreSettings(this ContainerOptions options)
+        {
+            options.EnableVariance = false;
+            return options;
+        }
+    }
+}

--- a/WebApplicationTest/Program.cs
+++ b/WebApplicationTest/Program.cs
@@ -1,0 +1,93 @@
+using LightInject;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using System.Collections.Generic;
+
+var builder = WebApplication.CreateBuilder(args);
+
+#region custom code for lightinject test
+builder.Host
+    .UseLightInject()
+    .ConfigureContainer<ServiceContainer>(container =>
+    {
+        ConfigureContainer(container);
+        ConfigureServicesWithContainer(container, builder.Services);
+    });
+
+#endregion custom code for lightinject test
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+////builder.Services.AddEndpointsApiExplorer();
+//builder.Services.AddSwaggerGen()
+//    .AddSwaggerGenNewtonsoftSupport();
+
+var app = builder.Build();
+
+//Debug: in VS
+//breakpoint in de ConsoleLoggerProvider constructor
+//var test = new ConsoleLoggerProvider();
+
+
+// Configure the HTTP request pipeline.
+if (!app.Environment.IsDevelopment())
+{
+
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.Run();
+
+
+#region custom code for lightinject test
+void ConfigureContainer(IServiceContainer container)
+{
+    container.RegisterSingleton<ApiInformation>(factory => new());
+}
+
+void ConfigureServicesWithContainer(IServiceContainer container, IServiceCollection services)
+{
+    var apiInformation = new ApiInformation();
+    //How to test the bug?
+    //Uncomment line below
+    //apiInformation = container.GetInstance<ApiInformation>();
+
+
+    var swaggerDocuments = new Dictionary<string, OpenApiInfo>();
+    swaggerDocuments.Add("1.0", new OpenApiInfo
+    {
+        //Title = apiInformation.Title,
+        Version = "1.0",
+        Description = apiInformation.Description,
+        //Contact = new OpenApiContact { Name = apiInformation.Contact?.Name, Email = apiInformation.Contact?.Email },
+        //TermsOfService = !apiInformation.TermsOfServiceUri.IsNullOrWhitespace() ? new System.Uri(apiInformation.TermsOfServiceUri) : null,
+        //License = !apiInformation.LicenseUri.IsNullOrWhitespace() ? new OpenApiLicense { Name = apiInformation.LicenseName, Url = new System.Uri(apiInformation.LicenseUri) } : null
+    });
+
+    builder.Services.AddSwaggerGen(c =>
+    {
+        foreach (var swaggerDoc in swaggerDocuments)
+            c.SwaggerDoc(swaggerDoc.Key, swaggerDoc.Value);
+    });
+}
+
+public class ApiInformation
+{
+    public string Description { get; set; }
+}
+
+#endregion custom code for lightinject test

--- a/WebApplicationTest/Properties/launchSettings.json
+++ b/WebApplicationTest/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55878",
+      "sslPort": 44351
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5193",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7042;http://localhost:5193",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/WebApplicationTest/WeatherForecast.cs
+++ b/WebApplicationTest/WeatherForecast.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace WebApplicationTest
+{
+    public class WeatherForecast
+    {
+        public DateOnly Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/WebApplicationTest/WebApplicationTest.csproj
+++ b/WebApplicationTest/WebApplicationTest.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
+	  <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\LightInject.Microsoft.DependencyInjection\LightInject.Microsoft.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WebApplicationTest/WebApplicationTest.http
+++ b/WebApplicationTest/WebApplicationTest.http
@@ -1,0 +1,6 @@
+@WebApplicationTest_HostAddress = http://localhost:5193
+
+GET {{WebApplicationTest_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/WebApplicationTest/appsettings.Development.json
+++ b/WebApplicationTest/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/WebApplicationTest/appsettings.json
+++ b/WebApplicationTest/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Adds a web api project.

Search for the "How to test the bug" text in the program.cs file.

Reason for the exception:
- the LightInject container is configured with registrations first (`ConfigureContainer()` method)
- services are added to the IServiceCollection by using the registered classes on the LightInject container (`ConfigureServicesWithContainer()` method)
- because an instance is retrieved from the LightInject container, the line `var app = builder.Build()` throws an exception
   this was not the case in LI.MS.DI v3.x.
   It seems that when an instance is retrieved from the LightInject container, only one ConsoleFormatter is resolved. When nothing is retrieved from the container all 3 instances of ConsoleFormatter are resolved.

In our projects, know that
- `ConfigureContainer()` does assembly scanning and registers hundreds of classes
- `ConfigureServicesWithContainer()` needs multiple instances with configuration on how to register the services